### PR TITLE
scopeName should be source.css.postcss

### DIFF
--- a/grammars/postcss.cson
+++ b/grammars/postcss.cson
@@ -1312,4 +1312,3 @@
     'name': 'support.constant.color.w3c-standard-color-name.postcss'
   }
 ]
-'scopeName': 'source.postcss'


### PR DESCRIPTION
It is set to `source.css.postcss` up top, but then overwritten at the bottom to just `source.postcss`
