### PR TITLE
Fix SugarSS scope

### DIFF
--- a/grammars/sugarss.cson
+++ b/grammars/sugarss.cson
@@ -244,4 +244,4 @@
     'name': 'support.constant.color.w3c-standard-color-name.postcss'
   }
 ]
-'scopeName': 'source.postcss'
+'scopeName': 'source.css.postcss.sugarss'


### PR DESCRIPTION
Changes the scope of SugarSS files to `source.css.postcss.sugarss`.

If you would instead prefer `source.css.sugarss` as [was used](https://github.com/danielbayley/atom-language-postcss-sugarss/blob/v0.1.0/grammars/sugarss.cson) in the other package I can update the PR to that, I went with `source.css.postcss.sugarss` though as it seems SugarSS is an extension of PostCSS so it makes sense to me that the scope reflects that.

I don't use either of them though, so I will gladly change it to the other scope if that is an issue getting this merged.

Fixes #10.
Helps with https://github.com/AtomLinter/linter-stylelint/issues/204.
